### PR TITLE
Update the release annotation docs

### DIFF
--- a/articles/azure-monitor/app/annotations.md
+++ b/articles/azure-monitor/app/annotations.md
@@ -14,16 +14,19 @@ Annotations show where you deployed a new build, or other significant events. An
 
 Release annotations are a feature of the cloud-based Azure Pipelines service of Azure DevOps.
 
-If your subscription has an Application Insights resource linked to it and you use one of the following deployment tasks, then you don't need to configure anything else.
+If the following criteria is met, then the deployment task will create the release annotation automatically:
+1. The resource you are deploying to is linked to Application Insights (via the `APPINSIGHTS_INSTRUMENTATIONKEY` app setting).
+2. The Application Insights resource is in the same subscription as the resource you are deploying to.
+3. You are using one of these Azure DevOps pipeline tasks:
 
-| Task code                 | Task name                     | Versions     |
-|---------------------------|-------------------------------|--------------|
-| AzureAppServiceSettings   | Azure App Service Settings    | Any          |
-| AzureRmWebAppDeployment   | Azure App Service deploy      | V3 and above |
-| AzureFunctionApp          | Azure Functions               | Any          |
-| AzureFunctionAppContainer | Azure Functions for container | Any          |
-| AzureWebAppContainer      | Azure Web App for Containers  | Any          |
-| AzureWebApp               | Azure Web App                 | Any          |
+    | Task code                 | Task name                     | Versions     |
+    |---------------------------|-------------------------------|--------------|
+    | AzureAppServiceSettings   | Azure App Service Settings    | Any          |
+    | AzureRmWebAppDeployment   | Azure App Service deploy      | V3 and above |
+    | AzureFunctionApp          | Azure Functions               | Any          |
+    | AzureFunctionAppContainer | Azure Functions for container | Any          |
+    | AzureWebAppContainer      | Azure Web App for Containers  | Any          |
+    | AzureWebApp               | Azure Web App                 | Any          |
 
 > [!NOTE]
 > If you’re still using the Application Insights annotation deployment task, you should delete it.


### PR DESCRIPTION
I updated the release annotation docs to better describe the scenario when the release annotation will automatically be created. The current wording made it seem like the Application Insights resource needed to be in the same subscription as the Azure DevOps instance.